### PR TITLE
Added recogniser for getter methods that contain uppercase instead of '_'

### DIFF
--- a/app/src/main/java/com/zeoflow/depot/db/Word.java
+++ b/app/src/main/java/com/zeoflow/depot/db/Word.java
@@ -44,18 +44,18 @@ public class Word
     @ColumnInfo(name = "word")
     private final String mWord;
 
-    private final Date date;
+    private final Date date_s;
 
-    public Word(@NonNull String mWord, Date date) {
+    public Word(@NonNull String mWord, Date date_s) {
         this.mWord = mWord;
-        this.date = date;
+        this.date_s = date_s;
     }
 
     @com.zeoflow.depot.Ignore
     public Word(@NonNull String word)
     {
         this.mWord = word;
-        this.date = new Date();
+        this.date_s = new Date();
     }
 
     @NonNull
@@ -64,8 +64,8 @@ public class Word
         return this.mWord;
     }
 
-    public Date getDate() {
-        return date;
+    public Date getDateS() {
+        return date_s;
     }
 
 }

--- a/compiler/src/main/kotlin/com/zeoflow/depot/vo/Field.kt
+++ b/compiler/src/main/kotlin/com/zeoflow/depot/vo/Field.kt
@@ -98,6 +98,19 @@ data class Field(
                 result.add(name.substring(1).decapitalize(Locale.US))
             }
 
+            if (name.contains('_')) {
+                val nameSplits = name.split('_')
+                var nameFinal = ""
+                for (nameSplit in nameSplits) {
+                    if (nameFinal == "") {
+                        nameFinal = nameSplit
+                    } else {
+                        nameFinal += nameSplit.capitalize(Locale.US)
+                    }
+                }
+                result.add(nameFinal)
+            }
+
             if (typeName == TypeName.BOOLEAN || typeName == TypeName.BOOLEAN.box()) {
                 if (name.length > 2 && name.startsWith("is") && name[2].isUpperCase()) {
                     result.add(name.substring(2).decapitalize(Locale.US))

--- a/dispatcher-compiler/src/main/java/com/zeoflow/depot/dispatcher/processor/atom/AtomAnnotatedClass.java
+++ b/dispatcher-compiler/src/main/java/com/zeoflow/depot/dispatcher/processor/atom/AtomAnnotatedClass.java
@@ -142,7 +142,6 @@ public class AtomAnnotatedClass
                         }
                     }
                 }
-                System.out.println("converters added");
             }
         }
 


### PR DESCRIPTION
## Table of Contents
### Link to GitHub issues it solves
closes #10 
### Description
Added recogniser for getter methods that contain uppercase instead of '_'

###### [Contributing](https://github.com/zeoflow/depot/blob/master/docs/contributing.md) has more information and tips for a great pull request.